### PR TITLE
Fix check_obs_against_forecast

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpPoint
 Title: Point verifition for NWP forecasts
-Version: 0.0.0.9099
+Version: 0.0.0.9100
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]", 
     "Alex Deckmyn <alex.deckmyn@meteo.be> [aut]"
@@ -18,7 +18,7 @@ LinkingTo:
     Rcpp
 Imports: 
     Rcpp,
-    dplyr,
+    dplyr >= 1.0.0,
     tidyr,
     readr,
     verification,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ LinkingTo:
     Rcpp
 Imports: 
     Rcpp,
-    dplyr >= 1.0.0,
-    tidyr,
+    dplyr (>= 1.0.0),
+    tidyr (>= 1.0.0),
     readr,
     verification,
     tibble,

--- a/R/check_obs_against_fcst.R
+++ b/R/check_obs_against_fcst.R
@@ -1,16 +1,22 @@
 #' Observation error check against forecast
 #'
-#' For each station (SID) and lead time the standard deviation of the forecast
-#' over all forecast cycles and models (mname), and in the case of an eps
-#' forecast, the ensemble members is computed. The difference between the
-#' observation and the forecast is expected to be smaller than a number of
-#' multiples of the standard deviation. The number of multiples of the standard
-#' deviation can be supplied or a default value used depending on the parameter.
+#' For each stratification the standard deviation of the forecast over all
+#' forecast cycles and models (mname), and in the case of an eps forecast, the
+#' ensemble members is computed. The difference between the observation and the
+#' forecast is expected to be smaller than a number of multiples of the standard
+#' deviation. The number of multiples of the standard deviation can be supplied
+#' or a default value used depending on the parameter.
+#'
 #' @param .fcst A data frame of class \code{harp_point_forecast_obs}.
 #' @param parameter The forecast parameter.
 #' @param num_sd_allowed The number of standard deviations of the forecast that
 #'   the difference between the forecast and the observation must be smaller
 #'   than.
+#' @param stratification The columns to stratify the data by when computing the
+#'   allowed tolerance. In most cases the column must exist in the input data,
+#'   but "quarter_day" can be passed to divide the observations into classes of
+#'   [0, 6), [6, 12), [12, 18) and [18, 24) hour of day. The default behaviour
+#'   is to stratify by station ("SID") and "quarter_day".
 #'
 #' @return A data frame of class \code{harp_point_forecast_obs} with an
 #'   attribute named \code{removed_cases} containing a data frame of the removed
@@ -19,7 +25,9 @@
 #'
 #' @examples
 
-check_obs_against_fcst <- function(.fcst, parameter, num_sd_allowed = NULL) {
+check_obs_against_fcst <- function(
+  .fcst, parameter, num_sd_allowed = NULL, stratification = c("SID", "quarter_day")
+) {
 
   parameter_quo  <- rlang::enquo(parameter)
   parameter_expr <- rlang::quo_get_expr(parameter_quo)
@@ -47,42 +55,83 @@ check_obs_against_fcst <- function(.fcst, parameter, num_sd_allowed = NULL) {
 
   if (num_sd_allowed > 0) {
 
-    tolerance <- .fcst %>%
-      join_models(
-        by = c(
-          "SID",
-          "leadtime",
-          "fcst_cycle",
-          "fcdate",
-          "validdate",
-          parameter_name
+    tolerance <- join_models(
+      .fcst,
+      by = Reduce(
+        union,
+        lapply(
+          .fcst,
+          function(x) {
+            grep(
+              "_mbr[[:digit:]]+$|_det$", colnames(x),
+              value = TRUE, invert = TRUE
+            )
+          }
         )
       )
+    )[[1]]
 
-    tolerance_df <- ens_spread_and_skill(
+    # Create extra columns for stratifying
+    if (!is.element("valid_hour", colnames(tolerance))) {
+
+      if (!is.element("validdate", colnames(tolerance))) {
+        stop(".fcst must have `validdate` column.")
+      }
+
+      if (is.numeric(tolerance[["validdate"]])) {
+        tolerance <- expand_date(tolerance, .data[["validdate"]])
+      } else if (inherits(tolerance[["validdate"]], "POSIXct")) {
+        tolerance <- dplyr::mutate(
+          tolerance,
+          valid_hour = lubridate::hour(.data[["validdate"]]),
+          valid_month = lubridate::month(.data[["validdate"]])
+        )
+      } else {
+        stop("Cannot convert validdate column to hour and months")
+      }
+
+    }
+
+    if (is.element("quarter_day", stratification)) {
+      tolerance <- dplyr::mutate(
+        tolerance,
+        quarter_day = cut(.data[["valid_hour"]], seq(0, 24, 6), right = FALSE)
+      )
+    }
+
+    tolerance_df <- tidyr::pivot_longer(
       tolerance,
-      !! parameter_quo,
-      groupings = c("SID", "leadtime")
-    )$ens_summary_scores %>%
-      dplyr::ungroup() %>%
-      dplyr::transmute(
-        .data$SID,
-        .data$leadtime,
-        tolerance_allowed = .data$spread * num_sd_allowed
+      tidyselect::matches("_mbr[[:digit:]]+$|_det$")
+    ) %>%
+      dplyr::group_by(!!!rlang::syms(stratification)) %>%
+      dplyr::summarise(
+        tolerance_allowed = stats::sd(.data[["value"]]) * .env[["num_sd_allowed"]],
+        num_cases         = dplyr::n()
       )
 
     tolerance <- suppressWarnings(suppressMessages(join_to_fcst(
       tolerance,
       tolerance_df,
-      by = c("SID", "leadtime"),
+      by = stratification,
       force_join = TRUE
     )))
 
-    tolerance <- tolerance[[1]] %>%
-      dplyr::mutate_at(
-        dplyr::vars(contains("_mbr")),
-        dplyr::funs(abs(. - !! parameter_quo))
+    tolerance <- dplyr::mutate(
+      tolerance,
+      dplyr::across(
+        dplyr::matches("_mbr[[:digit:]]+$|_det$"),
+        ~abs(. - !!parameter_quo)
       )
+    )
+
+    tolerance <- dplyr::mutate(
+      tolerance,
+      min_diff = matrixStats::rowMins(
+        as.matrix(
+          dplyr::select(tolerance, dplyr::matches("_mbr[[:digit:]]+$|_det$"))
+        )
+      )
+    )
 
     tolerance <- tolerance %>%
       dplyr::mutate(

--- a/man/check_obs_against_fcst.Rd
+++ b/man/check_obs_against_fcst.Rd
@@ -4,7 +4,12 @@
 \alias{check_obs_against_fcst}
 \title{Observation error check against forecast}
 \usage{
-check_obs_against_fcst(.fcst, parameter, num_sd_allowed = NULL)
+check_obs_against_fcst(
+  .fcst,
+  parameter,
+  num_sd_allowed = NULL,
+  stratification = c("SID", "quarter_day")
+)
 }
 \arguments{
 \item{.fcst}{A data frame of class \code{harp_point_forecast_obs}.}
@@ -14,6 +19,12 @@ check_obs_against_fcst(.fcst, parameter, num_sd_allowed = NULL)
 \item{num_sd_allowed}{The number of standard deviations of the forecast that
 the difference between the forecast and the observation must be smaller
 than.}
+
+\item{stratification}{The columns to stratify the data by when computing the
+allowed tolerance. In most cases the column must exist in the input data,
+but "quarter_day" can be passed to divide the observations into classes of
+[0, 6), [6, 12), [12, 18) and [18, 24) hour of day. The default behaviour
+is to stratify by station ("SID") and "quarter_day".}
 }
 \value{
 A data frame of class \code{harp_point_forecast_obs} with an
@@ -21,10 +32,10 @@ A data frame of class \code{harp_point_forecast_obs} with an
   cases.
 }
 \description{
-For each station (SID) and lead time the standard deviation of the forecast
-over all forecast cycles and models (mname), and in the case of an eps
-forecast, the ensemble members is computed. The difference between the
-observation and the forecast is expected to be smaller than a number of
-multiples of the standard deviation. The number of multiples of the standard
-deviation can be supplied or a default value used depending on the parameter.
+For each stratification the standard deviation of the forecast over all
+forecast cycles and models (mname), and in the case of an eps forecast, the
+ensemble members is computed. The difference between the observation and the
+forecast is expected to be smaller than a number of multiples of the standard
+deviation. The number of multiples of the standard deviation can be supplied
+or a default value used depending on the parameter.
 }

--- a/man/join_to_fcst.Rd
+++ b/man/join_to_fcst.Rd
@@ -8,7 +8,7 @@ join_to_fcst(
   .fcst,
   .join,
   join_type = c("inner", "left", "right", "full", "semi", "anti"),
-  by = "SID",
+  by = NULL,
   force_join = FALSE,
   keep_x = TRUE,
   keep_y = FALSE,
@@ -27,7 +27,9 @@ more details.}
 
 \item{by}{Which columns to join by - if set to NULL a natural join will be
 done, using all variables with common names across .fcst and .join. The
-default is to join using only the SID column.}
+default is to join using all common columns in .fcst and .join excluding
+lat, lon and elev. This is because they may be stored to different levels of
+precision and the join will thus fail.}
 
 \item{force_join}{Set to TRUE to force the join to happen even if the units
 in .fcst and .join are not compatible.}


### PR DESCRIPTION
This PR fixes #30 

Additionally, the calculation of tolerances is done more sensible and the user now has control over how to stratify the data when computing the standard deviations of the forecast data. 

The previous default was to do it by SID and leadtime, but now the default is to do it by SID and which quarter of the day the observation time is - [0, 6), [6, 12), [12, 18), or [18, 24). This results is more sensible tolerances based on time of day and location. 

