### PR TITLE
Bugfix in CRPS plus a few speed improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpPoint
 Title: Point verifition for NWP forecasts
-Version: 0.0.0.9102
+Version: 0.0.0.9103
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]", 
     "Alex Deckmyn <alex.deckmyn@meteo.be> [aut]"

--- a/R/ens_crps.R
+++ b/R/ens_crps.R
@@ -63,7 +63,7 @@ ens_crps.default <- function(.fcst, parameter, groupings = "leadtime", num_ref_m
       dplyr::select(dplyr::contains("_mbr")) %>%
       dplyr::select_if(~sum(!is.na(.)) > 0)
     )
-    res       <- mean(SpecsVerification::EnsCrps(fcst, obs, R.new = R_new))
+    res       <- mean(SpecsVerification::enscrps_cpp(fcst, obs, R_new = R_new))
     if (show_progress) {
       fair_crps_progress$tick()
     }

--- a/R/ens_verify.R
+++ b/R/ens_verify.R
@@ -247,13 +247,16 @@ get_climatology <- function(.fcst, parameter, thresholds, climatology) {
 add_attributes <- function(.verif, .fcst, parameter) {
   parameter <- rlang::enquo(parameter)
 
-  dates     <- unlist(purrr::map(.fcst, "fcdate"))
-  SIDs      <- unlist(purrr::map(.fcst, "SID"))
+  date_range  <- function(x) range(purrr::pluck(x, "fcdate"))
+  unique_sids <- function(x) unique(purrr::pluck(x, "SID"))
+
+  dates    <- unlist(purrr::map(.fcst, date_range), use.names = FALSE)
+  num_sids <- length(unique(unlist(purrr::map(.fcst, unique_sids), use.names = FALSE)))
 
   attr(.verif, "parameter")    <- rlang::quo_name(parameter)
   attr(.verif, "start_date")   <- harpIO::unixtime_to_str_datetime(min(dates), harpIO::YMDh)
   attr(.verif, "end_date")     <- harpIO::unixtime_to_str_datetime(max(dates), harpIO::YMDh)
-  attr(.verif, "num_stations") <- length(unique(SIDs))
+  attr(.verif, "num_stations") <- num_sids
 
   .verif
 }

--- a/R/harp_crps.R
+++ b/R/harp_crps.R
@@ -5,6 +5,13 @@ harp_crps <- function (.fcst, .param) {
 
   param <- rlang::enquo(.param)
   obs <- .fcst %>% dplyr::pull(!! param)
+  # Accounting problems occur when there are many forecast -
+  # observation pairs that have the exact same value, e.g. for
+  # cloud amount in oktas. This is fixed by adding a very small
+  # random number to the observations - here 1e-6 * std dev of obs
+  # is used as the standard deviation in the random number generation
+  # from a Gaussian distribution
+  obs <- obs + rnorm(length(obs), 0, 1e-6 * stats::sd(obs))
   eps <- .fcst %>%
     dplyr::select(dplyr::contains("_mbr")) %>%
     dplyr::select_if(~sum(!is.na(.)) > 0)


### PR DESCRIPTION
This PR introduces a few speed ups to deterministic verification and fixes a problem with CRPS that arose when forecast - observation pairs have the exact same numerical value. Generally this only manifests itself for parameters such as cloud amount in oktas giving a CRPS that is too small. The problem is fixed by adding a very small random number number to each observation. This means that no forecast - observation pair has the exact same numerical value while having no impact on the CRPS in the general case. 