### PR TITLE
Restore num_cases etc for threshold scores

### DIFF
--- a/R/sweepers.R
+++ b/R/sweepers.R
@@ -191,7 +191,10 @@ sweep_thresh_meta <- function(df) {
     num_cases_forecasted = purrr::map_int(
       .data[["metadata"]], "num_cases_forecast"
     )
-  )[grep("metadata", colnames(df), value = TRUE, invert = TRUE)]
+  )[grep("metadata",
+         c(colnames(df),"num_cases","num_stations","num_cases_total","num_cases_observed","num_cases_forecasted"),
+         value = TRUE,
+         invert = TRUE)]
 }
 
 # Deterministic


### PR DESCRIPTION
Num cases etc are missing from the threshold scores. Seems to be due to the new column names not being recognised when the mutate and grep are done in one step.

```
library(harp)
aa <- fake_point_data("2023010100","A",members = seq(0,5))
bb <- ens_verify(aa,parameter="obs",threshold=c(0,1))
print(names(bb[[2]]))
[1] "fcst_model"              "threshold"               "lead_time"               "brier_score"             "brier_skill_score"      
[6] "brier_score_reliability" "brier_score_resolution"  "brier_score_uncertainty" "bss_ref_climatology"     "reliability"            
[11] "roc"                     "roc_area"                "economic_value"          "tw_crps"                 "Type"        
```