### PR TITLE
Correct behaviour of clean_thresholds for between comparator

### DIFF
--- a/R/det_verify.R
+++ b/R/det_verify.R
@@ -567,7 +567,7 @@ clean_thresholds <- function(all_data, thresholds, comparator) {
     first_last <- which(
       vapply(
         thresholds,
-        function(x) any((data_range <= max(x) & data_range >= min(x))),
+        function(x) (min(data_range) <= max(x) & max(data_range) >= min(x)),
         logical(1)
       )
     )

--- a/R/det_verify.R
+++ b/R/det_verify.R
@@ -564,13 +564,13 @@ clean_thresholds <- function(all_data, thresholds, comparator) {
   }
 
   if (comparator == "between") {
-    first_last <- which(
+    first_last <- range(which(
       vapply(
         thresholds,
         function(x) (min(data_range) <= max(x) & max(data_range) >= min(x)),
         logical(1)
       )
-    )
+    ))
     return(thresholds[do.call(seq, as.list(first_last))])
   }
 


### PR DESCRIPTION
At the moment `clean_thresholds` can drop valid "between" groups in the case where `thresholds` does not span the range of fcst+obs e.g.

```
> fcst <- fake_point_data(fcst_dttm = "2026010100",fcst_model="test")
> range(fcst[c("fcst","obs")])
[1] -5.90227  4.32289
> bb <- det_verify(fcst,"obs",thresholds = list(c(0,1),c(1,2),c(2,3)),comparator = "between")
det: summary for lead_time ?
det: hexbin for lead_time ?
? Threshold: ge_0_le_1
det: threshold for threshold & lead_time
```

I think this change aligns with the purpose of `clean_thresholds`.